### PR TITLE
Thiatt/fix versioning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,29 +4,22 @@ Please include a summary of the change and which issue is fixed. Please also inc
 
 Fixes # (issue)
 
-<<<<<<< HEAD
-## Type of change
-
-Please delete options that are not relevant and mark one option with an "x".
-=======
 ## Primary Components Effected
+
 Please mark one option with an "x".
 
 - [ ] Shifter (Core CLI and Server Application)
 - [ ] Shifter UI (The Web Interface)
 
 ## Type of change
+
 Please mark one option with an "x".
->>>>>>> thiatt/ft_server
 
 - [ ] #RELEASE New Collection of Features (containing breaking and non-breaking changes)
 - [ ] #FT New feature (non-breaking change which adds functionality)
 - [ ] #BUG Bug Fix (non-breaking change which fixes an issue)
 - [ ] #PATCH Patch (non-breaking change which modifies only non-code object [Docs, Readme])
-<<<<<<< HEAD
-=======
-
 
 ## Developer / Author Notes
+
 Please feel free to provide any additional notes, content or context relating to this PR and subsequent contribution.
->>>>>>> thiatt/ft_server

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@ Please mark one option with an "x".
 
 - [ ] Shifter (Core CLI and Server Application)
 - [ ] Shifter UI (The Web Interface)
+- [ ] Cross Component Configuration (.github workflows, templates, docs, .MD files)
 
 ## Type of change
 

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -3,46 +3,14 @@ on:
   push:
     branches:
       - main
+
 jobs:
   release-on-push:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: jwalton/gh-find-current-pr@v1
-        id: getPRType
-        with:
-          # Can be "open", "closed", or "all".  Defaults to "open".
-          state: open
-      - id: string
-        uses: ASzc/change-string-case-action@v2
-        with:
-          string: steps.getPRType.outputs.body
-      - name: "PATCH"
-        uses: rymndhng/release-on-push-action@master
-        if: contains(${{ steps.string.outputs.lowercase }}, lowercase('[x] /#patch'))
+      - uses: rymndhng/release-on-push-action@master
         with:
           bump_version_scheme: patch
           use_github_release_notes: true
-      #- name: "BUG"
-      #  uses: rymndhng/release-on-push-action@master
-      #  if: contains(${{ steps.string.outputs.lowercase }}, lowercase('[x] /#bug'))
-      #  with:
-      #    bump_version_scheme: patch
-      #    use_github_release_notes: true
-      #- name: "FEATURE"
-      #  uses: rymndhng/release-on-push-action@master
-      #  if: contains(${{ steps.string.outputs.lowercase }}, lowercase('[x] /#ft'))
-      #  with:
-      #    bump_version_scheme: minor
-      #    use_github_release_notes: true
-      #- name: "RELEASE"
-      #  uses: rymndhng/release-on-push-action@master
-      #  if: contains(${{ steps.string.outputs.lowercase }}, lowercase('[x] /#release'))
-      #  with:
-      #    bump_version_scheme: major
-<<<<<<< HEAD
-      #    use_github_release_notes: true
-=======
-      #    use_github_release_notes: true
->>>>>>> thiatt/ft_server

--- a/shifter-ui/.gitignore
+++ b/shifter-ui/.gitignore
@@ -18,8 +18,7 @@ coverage
 /cypress/screenshots/
 
 # Editor directories and files
-.vscode/*
-!.vscode/extensions.json
+.vscode
 .idea
 *.suo
 *.ntvs*

--- a/shifter-ui/.vscode/extensions.json
+++ b/shifter-ui/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["johnsoncodehk.volar", "johnsoncodehk.vscode-typescript-vue-plugin"]
-}


### PR DESCRIPTION
# Description
Simple branch to fix the git ignore to remove .vscode and patch the erroring configuration in the .guthub workflows. 

Fixes # (issue)
- ".github/workflows/auto-tag-release.yml" contained invalid syntax from a previous merge.
- ".github/PULL_REQUEST_TEMPLATE.md" contained invalid syntax from a previous merge.

## Primary Components Effected
Please mark one option with an "x".

- [ ] Shifter (Core CLI and Server Application)
- [ ] Shifter UI (The Web Interface)

## Type of change
Please mark one option with an "x".

- [ ] #RELEASE New Collection of Features (containing breaking and non-breaking changes)
- [ ] #FT New feature (non-breaking change which adds functionality)
- [ ] #BUG Bug Fix (non-breaking change which fixes an issue)
- [X] #PATCH Patch (non-breaking change which modifies only non-code object [Docs, Readme])

## Developer / Author Notes
Please feel free to provide any additional notes, content or context relating to this PR and subsequent contribution.

