### PR TITLE
Adding the simple output of the API endpoint to the Server Settingz page

### DIFF
--- a/shifter-ui/src/components/shifter/v1/status/settingz.vue
+++ b/shifter-ui/src/components/shifter/v1/status/settingz.vue
@@ -10,6 +10,15 @@ import DocumentationIcon from "../../../icons/IconDocumentation.vue";
     <template #icon>
       <DocumentationIcon />
     </template>
+    <template #heading>Shifter Server API Endpoint</template>
+
+   {{shifterConfig.API_BASE_URL}}
+  </DetailsListItem>
+
+  <DetailsListItem>
+    <template #icon>
+      <DocumentationIcon />
+    </template>
     <template #heading>Shifter Server Port</template>
 
    {{data.runningPort}}
@@ -57,6 +66,7 @@ import DocumentationIcon from "../../../icons/IconDocumentation.vue";
 </template>
 
 <script>
+import { shifterConfig } from "@/main"
 import { mapState, mapActions } from 'pinia'
 
 export default {


### PR DESCRIPTION
# Description

Changes to Shifter-UI
This release is very simple. Adding only some text to the /status/settingz  page that shows the current api endpoint for shifter server.

Fixes # (issue)

## Primary Components Effected

Please mark one option with an "x".

- [ ] Shifter (Core CLI and Server Application)
- [X] Shifter UI (The Web Interface)
- [ ] Cross Component Configuration (.github workflows, templates, docs, .MD files)

## Type of change

Please mark one option with an "x".

- [ ] #RELEASE New Collection of Features (containing breaking and non-breaking changes)
- [ ] #FT New feature (non-breaking change which adds functionality)
- [ ] #BUG Bug Fix (non-breaking change which fixes an issue)
- [X] #PATCH Patch (non-breaking change which modifies only non-code object [Docs, Readme])

## Developer / Author Notes

This should be the final test hands off deployments.